### PR TITLE
Store the bashbrew.json output instead of removing it

### DIFF
--- a/.github/workflows/update-docker.yml
+++ b/.github/workflows/update-docker.yml
@@ -73,8 +73,8 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.PAT_TOKEN }}
-          branch: update-${{ inputs.version }} | tr '.' '-'
-          commit-message: "Update to version ${{ inputs.version }}"
+          branch: update-${{ inputs.version }}
+          commit-message: "Update for version ${{ inputs.version }}"
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           delete-branch: true
           signoff: true

--- a/.github/workflows/update-docker.yml
+++ b/.github/workflows/update-docker.yml
@@ -10,10 +10,16 @@ on:
     secrets:
       PAT_TOKEN:
         required: true
+    outputs:
+      bashbrew_output:
+        description: "Bashbrew output in JSON format"
+        value: ${{ jobs.build-new-docker.outputs.bashbrew_json }}
 
 jobs:
   build-new-docker:
     runs-on: ubuntu-latest
+    outputs:
+      bashbrew_json: ${{ steps.generate-bashbrew.outputs.bashbrew_content }}
     steps:
       - name: Validate inputs
         run: |
@@ -85,6 +91,7 @@ jobs:
           cd valkey-container
           BASHBREW_SCRIPTS=/home/runner/work/_actions/docker-library/bashbrew/v0.1.12/scripts
           "$BASHBREW_SCRIPTS/github-actions/generate.sh" > bashbrew_output.json
+          echo "bashbrew_content=$(cat bashbrew_output.json)" >> $GITHUB_OUTPUT
 
       - name: Update Docker Description File
         run: |

--- a/.github/workflows/update-docker.yml
+++ b/.github/workflows/update-docker.yml
@@ -61,11 +61,6 @@ jobs:
 
             # Run update script
             ./update.sh ${{ steps.strip_version.outputs.stripped_version }}
-  
-      - name: Ensure Up-to-Date Branch
-        run: |
-          git checkout main
-          git pull origin main --rebase
 
       - name: Check for Changes
         run: |


### PR DESCRIPTION
We can store the output so we can use it in the update-website workflow. This will reduce the chance of errors since we won't be re creating the bashbrew.json.