### PR TITLE
Remove ubuntu focal support

### DIFF
--- a/.github/actions/generate-package-build-matrix/build-config.json
+++ b/.github/actions/generate-package-build-matrix/build-config.json
@@ -1,15 +1,14 @@
 {
   "linux_targets": [
-
-      {
-        "arch": "x86_64",
-        "target": "ubuntu-20.04",
-        "type": "deb",
-        "platform": "focal"
-      },
       {
         "arch": "x86_64",
         "target": "ubuntu-22.04",
+        "type": "deb",
+        "platform": "jammy"
+      },
+      {
+        "arch": "arm64",
+        "target": "ubuntu-22.04-arm",
         "type": "deb",
         "platform": "jammy"
       },
@@ -18,12 +17,6 @@
         "target": "ubuntu-24.04",
         "type": "deb",
         "platform": "noble"
-      },
-      {
-        "arch": "arm64",
-        "target": "ubuntu-22.04-arm",
-        "type": "deb",
-        "platform": "jammy"
       },
       {
         "arch": "arm64",


### PR DESCRIPTION
Ubuntu 20.04 LTS **(FOCAL)** runner support removed on 2025-04-15.
For more details, see https://github.com/actions/runner-images/issues/11101

Also ubuntu focal reaching end of standard support on 31 May 2025: https://ubuntu.com/20-04