### PR TITLE
Add DCO signoff and skip doc updates for RC versions

### DIFF
--- a/.github/workflows/update-valkey-doc.yml
+++ b/.github/workflows/update-valkey-doc.yml
@@ -110,6 +110,7 @@ jobs:
           branch: update-docs-${{ inputs.version }}
           commit-message: "Update documentation for Valkey ${{ inputs.version }}"
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          delete-branch: true
           signoff: true
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           title: "Update documentation for Valkey ${{ inputs.version }}"

--- a/.github/workflows/update-valkey-doc.yml
+++ b/.github/workflows/update-valkey-doc.yml
@@ -22,7 +22,9 @@ jobs:
           PATCH=$(echo "$VERSION" | cut -d. -f3 | sed 's/-rc[0-9]*//')
           MINOR_VERSION=$(echo "$VERSION" | cut -d. -f1,2)
           
-          if [[ "$PATCH" != "0" ]]; then
+          if [[ "$VERSION" == *"-rc"* ]]; then
+            echo "is_major_minor=false" >> $GITHUB_OUTPUT
+          elif [[ "$PATCH" != "0" ]]; then
             echo "is_major_minor=false" >> $GITHUB_OUTPUT
           else
             echo "is_major_minor=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-valkey-doc.yml
+++ b/.github/workflows/update-valkey-doc.yml
@@ -107,6 +107,9 @@ jobs:
           path: valkey-doc
           branch: update-docs-${{ inputs.version }}
           commit-message: "Update documentation for Valkey ${{ inputs.version }}"
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          signoff: true
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           title: "Update documentation for Valkey ${{ inputs.version }}"
           body: |
             This PR updates documentation for version `${{ inputs.version }}`.


### PR DESCRIPTION
### Add DCO signoff and skip doc updates for RC versions
- Added signoff, committer, and author fields to the create-pull-request step to fix DCO check failures
- Added RC version check to skip documentation updates for release candidates

### Testing
RC Version is skipped: https://github.com/hanxizh9910/valkey-release-automation/actions/runs/23222621478/job/67498424943
GA Version(signoff included): https://github.com/hanxizh9910/valkey-doc/pull/14
