### PR TITLE
Use s3 prefix and download.valkey.io URL

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -539,7 +539,7 @@ jobs:
       - name: Generate site
         run: |
           PAGES_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
-          REPO_URL="https://${{ secrets.S3_BUCKET }}.s3.${{ secrets.S3_REGION }}.amazonaws.com"
+          REPO_URL="https://download.valkey.io/packaging"
           bash scripts/publish-repos.sh \
             "${{ needs.process-inputs.outputs.version }}" \
             "${{ steps.gpg.outputs.fingerprint }}" \
@@ -696,6 +696,6 @@ jobs:
           echo "Artifacts are available for download in the Actions tab." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           PAGES_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
-          REPO_URL="https://${{ secrets.S3_BUCKET }}.s3.${{ secrets.S3_REGION }}.amazonaws.com"
+          REPO_URL="https://download.valkey.io/packaging"
           echo ":package: **Package repository (S3):** ${REPO_URL}" >> $GITHUB_STEP_SUMMARY
           echo ":globe_with_meridians: **Install instructions:** [${PAGES_URL}](${PAGES_URL})" >> $GITHUB_STEP_SUMMARY

--- a/scripts/publish-repos.sh
+++ b/scripts/publish-repos.sh
@@ -26,9 +26,9 @@ mkdir -p "${SITE_DIR}"
 ################################################################################
 # Detect available versions from S3 bucket
 ################################################################################
-echo "Listing versions from s3://${S3_BUCKET}/..."
+echo "Listing versions from s3://${S3_BUCKET}/packaging/..."
 AVAILABLE_VERSIONS=""
-S3_DIRS=$(aws s3 ls "s3://${S3_BUCKET}/" --region "$S3_REGION" 2>/dev/null | awk '/PRE valkey-/ {gsub(/PRE /,""); gsub(/\//,""); print}') || true
+S3_DIRS=$(aws s3 ls "s3://${S3_BUCKET}/packaging/" --region "$S3_REGION" 2>/dev/null | awk '/PRE valkey-/ {gsub(/PRE /,""); gsub(/\//,""); print}') || true
 
 for vdir in $S3_DIRS; do
   ver="${vdir#valkey-}"

--- a/scripts/publish-to-s3.sh
+++ b/scripts/publish-to-s3.sh
@@ -136,10 +136,10 @@ gpg --armor --export "$GPG_KEY" > "${STAGING}/GPG-KEY-valkey.asc"
 # Upload to S3
 ################################################################################
 echo ""
-echo "Uploading to s3://${S3_BUCKET}/..."
+echo "Uploading to s3://${S3_BUCKET}/packaging/..."
 # Sync without --delete: multiple patch versions (e.g. 9.0.2, 9.0.4)
 # share the same repo directory (valkey-9.0/rpm/el9/x86_64/), so
 # --delete would remove packages from other patch releases.
-aws s3 sync "${STAGING}/" "s3://${S3_BUCKET}/"
+aws s3 sync "${STAGING}/" "s3://${S3_BUCKET}/packaging/"
 echo "Upload complete."
-echo "Packages available at: https://${S3_BUCKET}.s3.${S3_REGION}.amazonaws.com"
+echo "Packages available at: https://download.valkey.io/packaging"


### PR DESCRIPTION
Adapt the packaging workflow to use the existing S3 bucket with a `/packaging/` prefix, matching the existing release artifact pattern (`s3://${S3_BUCKET}/releases/`).

### Changes
- `publish-to-s3.sh`: sync to `s3://${S3_BUCKET}/packaging/` instead of bucket root
- `publish-repos.sh`: list versions from `s3://${S3_BUCKET}/packaging/`
- `packages.yml`: use `https://download.valkey.io/packaging` as REPO_URL (CloudFront-fronted) instead of raw S3 hostname

### Why
The S3 bucket is shared — releases live under `s3://${S3_BUCKET}/releases/`, so packages should live under `s3://${S3_BUCKET}/packaging/` rather than at the bucket root. The bucket is fronted by CloudFront at `download.valkey.io`, so package URLs become:
```
https://download.valkey.io/packaging/valkey-9.0/rpm/el9/x86_64/
https://download.valkey.io/packaging/valkey-9.0/deb/debian12/amd64/
https://download.valkey.io/packaging/GPG-KEY-valkey.asc
```

### Secrets needed
After merging, set these GitHub secrets:
| Secret | Value |
|--------|-------|
| `S3_BUCKET` | *(the existing S3 bucket name)* |
| `S3_REGION` | *(bucket region)* |
| `GPG_PRIVATE_KEY` | *(generate with setup-github-pages.sh)* |

`AWS_ROLE_TO_ASSUME` is already configured.