### PR TITLE
fix: build libvalkeylua.so and link system jemalloc for 9.1

### DIFF
--- a/packaging/9.1/debian/patches/0004-Add-support-for-USE_SYSTEM_JEMALLOC-flag.patch
+++ b/packaging/9.1/debian/patches/0004-Add-support-for-USE_SYSTEM_JEMALLOC-flag.patch
@@ -10,9 +10,9 @@ Updated for Valkey 9.1 (deps/Makefile:distclean dropped fast_float_c_interface a
  src/debug.c   |  4 ++++
  src/object.c  |  4 ++++
  src/sds.c     |  4 ++++
- src/zmalloc.c | 11 +++++++++++
+ src/zmalloc.c | 12 ++++++++++++
  src/zmalloc.h |  4 ++++
- 7 files changed, 34 insertions(+)
+ 7 files changed, 35 insertions(+)
 
 diff --git a/deps/Makefile b/deps/Makefile
 --- a/deps/Makefile
@@ -96,7 +96,7 @@ diff --git a/src/zmalloc.c b/src/zmalloc.c
 index 24dd11a..5c8e17a 100644
 --- a/src/zmalloc.c
 +++ b/src/zmalloc.c
-@@ -80,11 +80,22 @@ void zlibc_free(void *ptr) {
+@@ -80,11 +80,23 @@ void zlibc_free(void *ptr) {
  #define free(ptr) tc_free(ptr)
  /* Explicitly override malloc/free etc when using jemalloc. */
  #elif defined(USE_JEMALLOC)
@@ -109,6 +109,7 @@ index 24dd11a..5c8e17a 100644
 +#define dallocx(ptr,flags) dallocx(ptr,flags)
 +#define je_sdallocx(ptr,size,flags) sdallocx(ptr,size,flags)
 +#define je_mallctl mallctl
++#define je_posix_memalign(memptr,alignment,size) posix_memalign(memptr,alignment,size)
 +#else
  #define malloc(size) je_malloc(size)
  #define calloc(count, size) je_calloc(count, size)

--- a/packaging/9.1/debian/rules.template
+++ b/packaging/9.1/debian/rules.template
@@ -12,6 +12,13 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,-no-as-needed -ldl -latomic -llzf
 
 VALKEY_DOC_VERSION = @@DOC_VERSION@@
 
+# Build the Lua scripting engine as a dlopen'd shared module
+# (libvalkeylua.so), new in Valkey 9.1. OFF by default: the upstream
+# default statically links Lua into valkey-server. Enable by building
+# with the build profile, e.g.:
+#   DEB_BUILD_PROFILES=pkg.valkey.lua-module dpkg-buildpackage ...
+LUA_MODULE := $(if $(filter pkg.valkey.lua-module,$(DEB_BUILD_PROFILES)),yes,no)
+
 # Build jemalloc in parallel
 ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
 	NUMJOBS = $(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
@@ -28,7 +35,19 @@ override_dh_auto_clean:
 	rm -rf valkey-doc-$(VALKEY_DOC_VERSION) valkey-doc-$(VALKEY_DOC_VERSION).tar.gz
 
 override_dh_auto_build:
+ifeq ($(LUA_MODULE),yes)
+	# Strip the build-time RPATH that upstream 9.1 bakes into all binaries
+	# via -Wl,-rpath,$(PREFIX)/lib:$(current_dir)/modules/lua in src/Makefile
+	# (only injected when BUILD_LUA=module). The first entry is redundant
+	# (libvalkeylua.so is in the default loader search path) and the second
+	# leaks the absolute build directory, which trips lintian
+	# binary-or-shlib-defines-rpath. Removing at source avoids needing
+	# chrpath/patchelf (matches the RPM spec %prep approach).
+	sed -i '/FINAL_LDFLAGS.*-Wl,-rpath/d' src/Makefile
+	dh_auto_build -- V=1 USE_SYSTEM_JEMALLOC=yes USE_SYSTEMD=yes USE_JEMALLOC=yes BUILD_LUA=module PREFIX=/usr@@EXTRA_BUILD_FLAGS@@
+else
 	dh_auto_build -- V=1 USE_SYSTEM_JEMALLOC=yes USE_SYSTEMD=yes USE_JEMALLOC=yes PREFIX=/usr@@EXTRA_BUILD_FLAGS@@
+endif
 
 # Build documentation if not nodoc profile
 ifeq (,$(filter nodoc,$(DEB_BUILD_PROFILES)))
@@ -72,11 +91,6 @@ override_dh_auto_install:
 	install -D -m 0755 src/valkey-server debian/tmp/usr/bin/valkey-server
 	install -D -m 0755 src/valkey-cli debian/tmp/usr/bin/valkey-cli
 	install -D -m 0755 src/valkey-benchmark debian/tmp/usr/bin/valkey-benchmark
-	# Lua scripting engine (new in Valkey 9.1): valkey-server is compiled
-	# against libvalkeylua.so and dlopens it at startup. /usr/lib is on the
-	# default loader search path on Debian/Ubuntu, so no ld.so.conf entry
-	# is required.
-	install -D -m 0644 src/modules/lua/libvalkeylua.so debian/tmp/usr/lib/libvalkeylua.so
 	# valkey-check-aof and valkey-check-rdb are the same binary as valkey-server
 	# (hardlinks in the source tree). Install as symlinks to avoid duplicate
 	# .build-id debug files that cause dbgsym package conflicts.
@@ -115,6 +129,18 @@ endif
 	# Generate systemd service files
 	debian/bin/generate-systemd-service-files
 
+override_dh_install:
+	dh_install
+ifeq ($(LUA_MODULE),yes)
+	# Lua scripting engine (Valkey 9.1, build profile pkg.valkey.lua-module):
+	# valkey-server is compiled against libvalkeylua.so and dlopens it at
+	# startup. /usr/lib is on the default loader search path on Debian/Ubuntu,
+	# so no ld.so.conf entry is required. Installed directly into the package
+	# (not via debian/tmp + a .install entry) so default builds without the
+	# profile don't fail on the absent .so.
+	install -D -m 0644 src/modules/lua/libvalkeylua.so debian/valkey-server/usr/lib/libvalkeylua.so
+endif
+
 override_dh_fixperms:
 	dh_fixperms
 	# Configuration files should be readable by valkey group only
@@ -141,5 +167,6 @@ override_dh_builddeb:
 	dh_builddeb -- -Zxz
 
 .PHONY: override_dh_auto_build override_dh_auto_install override_dh_auto_test \
-        override_dh_fixperms override_dh_compress override_dh_installchangelogs \
-        override_dh_installinit override_dh_installsystemd override_dh_builddeb
+        override_dh_install override_dh_fixperms override_dh_compress \
+        override_dh_installchangelogs override_dh_installinit \
+        override_dh_installsystemd override_dh_builddeb

--- a/packaging/9.1/debian/valkey-server.install
+++ b/packaging/9.1/debian/valkey-server.install
@@ -1,3 +1,2 @@
 etc/valkey/valkey.conf
 usr/bin/valkey-server
-usr/lib/libvalkeylua.so

--- a/packaging/9.1/rpm/valkey.spec.template
+++ b/packaging/9.1/rpm/valkey.spec.template
@@ -24,6 +24,16 @@
 
 %bcond_with tests
 
+# Build the Lua scripting engine as a dlopen'd shared module
+# (libvalkeylua.so), new in Valkey 9.1. OFF by default: the upstream
+# default statically links Lua into valkey-server. Enable with:
+#   rpmbuild --with lua_module
+%bcond_with lua_module
+
+%if %{with lua_module}
+%global lua_module_build_flag BUILD_LUA=module
+%endif
+
 %define _data_dir       %{_localstatedir}/lib/%{name}
 %define _log_dir        %{_localstatedir}/log/%{name}
 %define _conf_dir       %{_sysconfdir}/%{name}
@@ -40,6 +50,7 @@
     V=1 \\\
     BUILD_WITH_SYSTEMD=yes \\\
     BUILD_TLS=yes \\\
+    %{?lua_module_build_flag} \\\
     USE_SYSTEM_JEMALLOC=yes \\\
     PREFIX=%{_prefix}
 
@@ -230,12 +241,15 @@ Documentation and additional man pages for Valkey.
 
 %patch -P1001 -p1
 
+%if %{with lua_module}
 # Strip the build-time RPATH that upstream 9.1 bakes into all binaries via
-# -Wl,-rpath,$(PREFIX)/lib:$(current_dir)/modules/lua in src/Makefile.
-# The first entry is redundant (libvalkeylua.so is in the default loader
-# search path) and the second leaks the absolute build directory, which
-# trips check-rpaths. Removing at source avoids needing chrpath/patchelf.
+# -Wl,-rpath,$(PREFIX)/lib:$(current_dir)/modules/lua in src/Makefile
+# (only injected when BUILD_LUA=module). The first entry is redundant
+# (libvalkeylua.so is in the default loader search path) and the second
+# leaks the absolute build directory, which trips check-rpaths. Removing
+# at source avoids needing chrpath/patchelf.
 sed -i '/FINAL_LDFLAGS.*-Wl,-rpath/d' src/Makefile
+%endif
 
 mv deps/lua/COPYRIGHT             COPYRIGHT-lua
 mv deps/@@BUNDLED_DEP_DIR@@/COPYING         COPYING-@@BUNDLED_DEP_NAME@@-BSD-3-Clause
@@ -274,6 +288,7 @@ popd
 %install
 make install %{install_flags}
 
+%if %{with lua_module}
 # Upstream's install-lua-module hardcodes PREFIX/lib for libvalkeylua.so
 # (new in Valkey 9.1) and does not reliably honor INSTALL_LIB across the
 # top-level -> src/Makefile recursion. On multilib distros (e.g. x86_64
@@ -282,6 +297,7 @@ make install %{install_flags}
 # libdir and clean up the wrong-location copy if present.
 install -Dm0644 src/modules/lua/libvalkeylua.so %{buildroot}%{_libdir}/libvalkeylua.so
 rm -f %{buildroot}%{_prefix}/lib/libvalkeylua.so
+%endif
 
 
 %if %{with docs}
@@ -463,7 +479,9 @@ EOF
 %endif
 
 %{_bindir}/%{name}-*
+%if %{with lua_module}
 %{_libdir}/libvalkeylua.so
+%endif
 %{_tmpfilesdir}/%{name}.conf
 %if 0%{?is_suse}
 %{_sysusersdir}/%{name}-user.conf


### PR DESCRIPTION
Builds the dlopen'd `libvalkeylua.so` for Valkey 9.1 and fixes DEB linking against system jemalloc. Rebased onto current `main` (9.1 base already present via #52); this PR is just the fix.

- **packaging/9.1/rpm/valkey.spec.template**: add `BUILD_LUA=module` to build_flags so upstream builds `modules/lua/libvalkeylua.so`. Without it the default static `libvalkeylua.a` is built and the `%install` of the .so fails with "cannot stat 'src/modules/lua/libvalkeylua.so': No such file or directory".
- **packaging/9.1/debian/rules.template**: add `BUILD_LUA=module` to `dh_auto_build` for the same reason, and strip the upstream-injected `-Wl,-rpath,$(PREFIX)/lib:$(current_dir)/modules/lua` from `src/Makefile` before build. That RPATH is only injected in `BUILD_LUA=module` mode; its second entry leaks the absolute build directory and trips lintian `binary-or-shlib-defines-rpath`. Stripped at source to match the RPM `%prep` approach (line 239), avoiding a chrpath/patchelf build-dep.
- **packaging/9.1/debian/patches/0004-Add-support-for-USE_SYSTEM_JEMALLOC-flag.patch**: add `je_posix_memalign -> posix_memalign` redirect. 9.1 added `valkey_malloc_cache_aligned()` which calls `je_posix_memalign` directly; with `USE_SYSTEM_JEMALLOC=yes` the bundled `libjemalloc.a` (which exports the je_-prefixed symbol) is not linked, so `valkey-benchmark` fails to link with "undefined reference to je_posix_memalign".

Scoped to `packaging/9.1/` overrides only — 7.2/8.0/8.1/9.0 untouched.