### PR TITLE
Replace AUTOMATION_PAT with Valkeyrie Bot GitHub App tokens

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -95,8 +95,7 @@ jobs:
     uses: ./.github/workflows/update-valkey-hashes.yml
     with:
       version: ${{ needs.process-inputs.outputs.version }}
-    secrets:
-      PAT_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+    secrets: inherit
 
   update-valkey-container:
     needs:
@@ -106,8 +105,7 @@ jobs:
     uses: ./.github/workflows/update-valkey-container.yml
     with:
       version: ${{ needs.process-inputs.outputs.version }}
-    secrets:
-      PAT_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+    secrets: inherit
 
   update-valkey-doc:
     needs:
@@ -117,8 +115,7 @@ jobs:
     uses: ./.github/workflows/update-valkey-doc.yml
     with:
       version: ${{ needs.process-inputs.outputs.version }}
-    secrets:
-      PAT_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+    secrets: inherit
   
   generate-build-matrix:
     needs:
@@ -185,8 +182,7 @@ jobs:
       version: ${{ needs.process-inputs.outputs.version }}
       bashbrew_json: ${{ needs.update-valkey-container.outputs.bashbrew_output }}
       try_valkey_uploaded: ${{ needs.update-try-valkey.outputs.try_valkey_uploaded }}
-    secrets:
-      PAT_TOKEN: ${{ secrets.AUTOMATION_PAT }}
+    secrets: inherit
 
   trigger-valkey-bundle:
     needs:
@@ -194,11 +190,21 @@ jobs:
       - update-valkey-container
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        if: needs.process-inputs.outputs.trigger_bundle == 'true'
+        id: generate-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.VALKEYRIE_BOT_APP_ID }}
+          private-key: ${{ secrets.VALKEYRIE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: valkey-bundle
+
       - name: Trigger Valkey Bundle Update
         if: needs.process-inputs.outputs.trigger_bundle == 'true'
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # Version 3
         with:
-          token: ${{ secrets.AUTOMATION_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: ${{ github.repository_owner }}/valkey-bundle
           event-type: valkey-release
           client-payload: >

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate token
-        if: needs.process-inputs.outputs.trigger_bundle == 'true'
+        if: needs.process-inputs.outputs.trigger_bundle == 'true' && github.repository_owner == 'valkey-io'
         id: generate-token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
@@ -204,7 +204,7 @@ jobs:
         if: needs.process-inputs.outputs.trigger_bundle == 'true'
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # Version 3
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
           repository: ${{ github.repository_owner }}/valkey-bundle
           event-type: valkey-release
           client-payload: >

--- a/.github/workflows/update-valkey-container.yml
+++ b/.github/workflows/update-valkey-container.yml
@@ -7,9 +7,6 @@ on:
         type: string
         description: "Valkey version that was released"
         required: true
-    secrets:
-      PAT_TOKEN:
-        required: true
     outputs:
       bashbrew_output:
         description: "Bashbrew output in JSON format"
@@ -27,6 +24,15 @@ jobs:
             echo "Invalid version format. Expected format: x.y.z or 'unstable'"
             exit 1
           fi
+
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.VALKEYRIE_BOT_APP_ID }}
+          private-key: ${{ secrets.VALKEYRIE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: valkey-container,valkey-release-automation
       
       - name: Set up bashbrew
         uses: docker-library/bashbrew@v0.1.13
@@ -46,14 +52,14 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/valkey-container
           path: valkey-container
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Checkout valkey-release-automation
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/valkey-release-automation
           path: valkey-release-automation
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -136,7 +142,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: valkey-container
           branch: update-${{ inputs.version }}
           commit-message: "Preparing changes for version ${{ inputs.version }}"

--- a/.github/workflows/update-valkey-container.yml
+++ b/.github/workflows/update-valkey-container.yml
@@ -53,14 +53,14 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/valkey-container
           path: valkey-container
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
 
       - name: Checkout valkey-release-automation
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/valkey-release-automation
           path: valkey-release-automation
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -143,7 +143,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
           path: valkey-container
           branch: update-${{ inputs.version }}
           commit-message: "Preparing changes for version ${{ inputs.version }}"

--- a/.github/workflows/update-valkey-container.yml
+++ b/.github/workflows/update-valkey-container.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Generate token
         id: generate-token
+        if: github.repository_owner == 'valkey-io'
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.VALKEYRIE_BOT_APP_ID }}
@@ -52,14 +53,14 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/valkey-container
           path: valkey-container
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
 
       - name: Checkout valkey-release-automation
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/valkey-release-automation
           path: valkey-release-automation
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -142,7 +143,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
           path: valkey-container
           branch: update-${{ inputs.version }}
           commit-message: "Preparing changes for version ${{ inputs.version }}"

--- a/.github/workflows/update-valkey-container.yml
+++ b/.github/workflows/update-valkey-container.yml
@@ -53,14 +53,14 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/valkey-container
           path: valkey-container
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}
 
       - name: Checkout valkey-release-automation
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/valkey-release-automation
           path: valkey-release-automation
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -143,7 +143,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}
           path: valkey-container
           branch: update-${{ inputs.version }}
           commit-message: "Preparing changes for version ${{ inputs.version }}"

--- a/.github/workflows/update-valkey-doc.yml
+++ b/.github/workflows/update-valkey-doc.yml
@@ -7,9 +7,6 @@ on:
         type: string
         description: "Version of the release"
         required: true
-    secrets:
-      PAT_TOKEN:
-        required: true
 
 jobs:
   update-valkey-doc:
@@ -32,6 +29,16 @@ jobs:
           
           echo "minor_version=$MINOR_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Generate token
+        if: steps.check-release.outputs.is_major_minor == 'true'
+        id: generate-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.VALKEYRIE_BOT_APP_ID }}
+          private-key: ${{ secrets.VALKEYRIE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: valkey-doc
+
       - name: Checkout valkey
         if: steps.check-release.outputs.is_major_minor == 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -45,7 +52,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ github.repository_owner }}/valkey-doc
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: valkey-doc
 
       - name: Setup Ruby
@@ -105,7 +112,7 @@ jobs:
         if: steps.check-release.outputs.is_major_minor == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: valkey-doc
           branch: update-docs-${{ inputs.version }}
           commit-message: "Update documentation for Valkey ${{ inputs.version }}"

--- a/.github/workflows/update-valkey-doc.yml
+++ b/.github/workflows/update-valkey-doc.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ github.repository_owner }}/valkey-doc
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
           path: valkey-doc
 
       - name: Setup Ruby
@@ -112,7 +112,7 @@ jobs:
         if: steps.check-release.outputs.is_major_minor == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
           path: valkey-doc
           branch: update-docs-${{ inputs.version }}
           commit-message: "Update documentation for Valkey ${{ inputs.version }}"

--- a/.github/workflows/update-valkey-doc.yml
+++ b/.github/workflows/update-valkey-doc.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ github.repository_owner }}/valkey-doc
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}
           path: valkey-doc
 
       - name: Setup Ruby
@@ -112,7 +112,7 @@ jobs:
         if: steps.check-release.outputs.is_major_minor == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}
           path: valkey-doc
           branch: update-docs-${{ inputs.version }}
           commit-message: "Update documentation for Valkey ${{ inputs.version }}"

--- a/.github/workflows/update-valkey-doc.yml
+++ b/.github/workflows/update-valkey-doc.yml
@@ -30,7 +30,7 @@ jobs:
           echo "minor_version=$MINOR_VERSION" >> $GITHUB_OUTPUT
 
       - name: Generate token
-        if: steps.check-release.outputs.is_major_minor == 'true'
+        if: steps.check-release.outputs.is_major_minor == 'true' && github.repository_owner == 'valkey-io'
         id: generate-token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ github.repository_owner }}/valkey-doc
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
           path: valkey-doc
 
       - name: Setup Ruby
@@ -112,7 +112,7 @@ jobs:
         if: steps.check-release.outputs.is_major_minor == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
           path: valkey-doc
           branch: update-docs-${{ inputs.version }}
           commit-message: "Update documentation for Valkey ${{ inputs.version }}"

--- a/.github/workflows/update-valkey-hashes.yml
+++ b/.github/workflows/update-valkey-hashes.yml
@@ -7,10 +7,6 @@ on:
         description: The version of Valkey to create.
         type: string
         required: true
-    secrets:
-      PAT_TOKEN:
-        description: PAT token for valkey-hashes repo.
-        required: true
 
 jobs:
   commit-hash:
@@ -23,10 +19,19 @@ jobs:
             exit 1
           fi
 
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.VALKEYRIE_BOT_APP_ID }}
+          private-key: ${{ secrets.VALKEYRIE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: valkey-hashes
+
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: ${{ github.repository_owner }}/valkey-hashes
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Ensure repository is initialized
         run: |
@@ -67,4 +72,4 @@ jobs:
           # Clean up the downloaded file
           rm "$FILENAME"
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/update-valkey-hashes.yml
+++ b/.github/workflows/update-valkey-hashes.yml
@@ -72,4 +72,4 @@ jobs:
           # Clean up the downloaded file
           rm "$FILENAME"
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/.github/workflows/update-valkey-hashes.yml
+++ b/.github/workflows/update-valkey-hashes.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: ${{ github.repository_owner }}/valkey-hashes
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.secrets.PAT_TOKEN }}
 
       - name: Ensure repository is initialized
         run: |

--- a/.github/workflows/update-valkey-hashes.yml
+++ b/.github/workflows/update-valkey-hashes.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: ${{ github.repository_owner }}/valkey-hashes
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.secrets.PAT_TOKEN }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
 
       - name: Ensure repository is initialized
         run: |
@@ -73,4 +73,4 @@ jobs:
           # Clean up the downloaded file
           rm "$FILENAME"
         env:
-          GITHUB_TOKEN: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}

--- a/.github/workflows/update-valkey-hashes.yml
+++ b/.github/workflows/update-valkey-hashes.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Generate token
         id: generate-token
+        if: github.repository_owner == 'valkey-io'
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.VALKEYRIE_BOT_APP_ID }}
@@ -31,7 +32,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: ${{ github.repository_owner }}/valkey-hashes
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
 
       - name: Ensure repository is initialized
         run: |

--- a/.github/workflows/update-valkey-website.yml
+++ b/.github/workflows/update-valkey-website.yml
@@ -16,7 +16,6 @@ on:
         description: "Whether try-valkey files were uploaded to S3"
         required: false
         default: 'false'
-    secrets:
 
 jobs:
   update-website:

--- a/.github/workflows/update-valkey-website.yml
+++ b/.github/workflows/update-valkey-website.yml
@@ -17,8 +17,6 @@ on:
         required: false
         default: 'false'
     secrets:
-      PAT_TOKEN:
-        required: true
 
 jobs:
   update-website:
@@ -30,6 +28,15 @@ jobs:
             echo "Invalid version format. Expected format: x.y.z or 'unstable'"
             exit 1
           fi
+
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.VALKEYRIE_BOT_APP_ID }}
+          private-key: ${{ secrets.VALKEYRIE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: valkey-io.github.io
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -47,7 +54,7 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/valkey-io.github.io
           path: valkey-io.github.io
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Format version for filename
         id: format-version
@@ -120,7 +127,7 @@ jobs:
         if: steps.update-website.outputs.has_changes == 'true' || steps.update-try-valkey.outputs.has_try_valkey_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: valkey-io.github.io
           branch: update-website-${{ inputs.version }}
           commit-message: "updated website for version ${{ inputs.version }}"

--- a/.github/workflows/update-valkey-website.yml
+++ b/.github/workflows/update-valkey-website.yml
@@ -127,7 +127,7 @@ jobs:
         if: steps.update-website.outputs.has_changes == 'true' || steps.update-try-valkey.outputs.has_try_valkey_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN  }}
           path: valkey-io.github.io
           branch: update-website-${{ inputs.version }}
           commit-message: "updated website for version ${{ inputs.version }}"

--- a/.github/workflows/update-valkey-website.yml
+++ b/.github/workflows/update-valkey-website.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Generate token
         id: generate-token
+        if: github.repository_owner == 'valkey-io'
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.VALKEYRIE_BOT_APP_ID }}
@@ -53,7 +54,7 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/valkey-io.github.io
           path: valkey-io.github.io
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN  }}
 
       - name: Format version for filename
         id: format-version

--- a/.github/workflows/update-valkey-website.yml
+++ b/.github/workflows/update-valkey-website.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/valkey-io.github.io
           path: valkey-io.github.io
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN  }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
 
       - name: Format version for filename
         id: format-version
@@ -127,7 +127,7 @@ jobs:
         if: steps.update-website.outputs.has_changes == 'true' || steps.update-try-valkey.outputs.has_try_valkey_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.PAT_TOKEN  }}
+          token: ${{ github.repository_owner == 'valkey-io' && steps.generate-token.outputs.token || secrets.AUTOMATION_PAT }}
           path: valkey-io.github.io
           branch: update-website-${{ inputs.version }}
           commit-message: "updated website for version ${{ inputs.version }}"


### PR DESCRIPTION
Each workflow/job now generates its own scoped installation token using actions/create-github-app-token with VALKEYRIE_BOT_APP_ID and VALKEYRIE_BOT_PRIVATE_KEY org secrets.

Token scoping:
- build-release.yml (trigger-valkey-bundle): valkey-bundle
- update-valkey-hashes.yml: valkey-hashes
- update-valkey-container.yml: valkey-container, valkey-release-automation
- update-valkey-doc.yml: valkey-doc
- update-valkey-website.yml: valkey-io.github.io

Called workflows no longer accept PAT_TOKEN as a secret interface; build-release.yml passes secrets: inherit so each called workflow can access the org-level app credentials directly.

Closes #53